### PR TITLE
Use dot to display

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,3 +1,5 @@
+source build/tests/algc-test-rbtree-gdb.py
+
 layout src
 b 15
 b 24
@@ -21,5 +23,7 @@ print-rbt *tree->root
 end
 
 r
+
+!dot -Txlib /tmp/rbt.dot &
 
 display v

--- a/script/algc-test-rbtree-gdb.py
+++ b/script/algc-test-rbtree-gdb.py
@@ -45,8 +45,5 @@ class PrintRBT(gdb.Command):
         with open("/tmp/rbt.dot", "w") as f:
             f.write(dot_cmd)
 
-        os.system("dot -Tsvg /tmp/rbt.dot > /tmp/rbt.svg")
-        os.system("xdg-open /tmp/rbt.svg")
-
 
 PrintRBT()


### PR DESCRIPTION
1、直接使用 `dot` 显示，不先转为 `svg`
2、gdb 调试时自动打开显示，不用手动打开